### PR TITLE
Typos fixed

### DIFF
--- a/Assets/SceneManagement/Editor/SceneManagementMenuItems.cs
+++ b/Assets/SceneManagement/Editor/SceneManagementMenuItems.cs
@@ -7,7 +7,7 @@ namespace SceneManagement.Editor
 {
     public static class SceneManagementMenuItems
     {
-        [MenuItem("Scene Managment/Create Scene Settings", false, 10)]
+        [MenuItem("Scene Management/Create Scene Settings", false, 10)]
         private static void CreateNewSceneLoaderSettings()
         {
             var settings = Resources.Load<SceneLoaderSettings>(nameof(SceneLoaderSettings));

--- a/Assets/SceneManagement/SceneLoader.cs
+++ b/Assets/SceneManagement/SceneLoader.cs
@@ -13,7 +13,7 @@ namespace SceneManagement
         #if SYMBOL_DEFINER_ASSET
         [SymbolDefiner(true)]
         #endif
-        private const string SceneManagementAsset = "SCENE_MANAGMENT_ASSET";
+        private const string SceneManagementAsset = "SCENE_MANAGEMENT_ASSET";
         private static readonly SceneLoaderSettings SceneLoaderSettings;
 
         static SceneLoader()


### PR DESCRIPTION
Fixed typos that caused to create two menu items **Scene Management** and **Scene Managment** separately.